### PR TITLE
Match all valid variables; sort variable; tabs over spaces

### DIFF
--- a/configuration.mock
+++ b/configuration.mock
@@ -15,6 +15,6 @@ data "template_file" "template1" {
   vars {
     t1_var1 = "${var.t1_var1}"
     t1-var2 = "${var.t1-var2}"
-    t1-var3 = "${var.t1-Var3}"
+    t1-var3 = "${var.t1-Var3}-${var.t1-inline}"
   }
 }

--- a/configuration.mock
+++ b/configuration.mock
@@ -9,3 +9,12 @@ resource "aws_nat_gateway" "nat" {
   subnet_id     = "${element(aws_subnet.public.*.id, count.index)}"
   count         = "${length(var.public_subnets)}"
 }
+
+data "template_file" "template1" {
+  template = "${file("${path.module}/template1.tpl")}"
+  vars {
+    t1_var1 = "${var.t1_var1}"
+    t1-var2 = "${var.t1-var2}"
+    t1-var3 = "${var.t1-Var3}"
+  }
+}

--- a/generator.go
+++ b/generator.go
@@ -72,6 +72,7 @@ func main() {
 	f, err := os.Create(dstFile)
 	checkError(err)
 
+	t.sortVars()
 	err = varTemplate.Execute(f, t.Variables)
 	checkError(err)
 	log.Infof("Variables are generated to %q file", dstFile)

--- a/generator.go
+++ b/generator.go
@@ -17,10 +17,9 @@ var tfFileExt = "*.tf"
 var dstFile = "./variables.tf"
 var varTemplate = template.Must(template.New("var_file").Parse(`{{range .}}
 variable "{{ . }}" {
-   description  = ""
+	description  = ""
 }
- {{end}}
-`))
+{{end}}`))
 
 func init() {
 	replacer = strings.NewReplacer(":", ".",

--- a/generator_test.go
+++ b/generator_test.go
@@ -41,8 +41,9 @@ func TestMatchVariable(t *testing.T) {
 	for _, text := range messages {
 		ter.matchVarPref(text, varPrefix)
 	}
-	if len(ter.Variables) != 1 {
-		t.Errorf("Should return one variable. but returned %d", len(ter.Variables))
+	if len(ter.Variables) != 4 {
+		t.Errorf("Should return four variable. but returned %d", len(ter.Variables))
+		t.Errorf("Variables found: %s", ter.Variables)
 	}
 
 }

--- a/generator_test.go
+++ b/generator_test.go
@@ -41,8 +41,8 @@ func TestMatchVariable(t *testing.T) {
 	for _, text := range messages {
 		ter.matchVarPref(text, varPrefix)
 	}
-	if len(ter.Variables) != 4 {
-		t.Errorf("Should return four variable. but returned %d", len(ter.Variables))
+	if len(ter.Variables) != 5 {
+		t.Errorf("Should return five variable. but returned %d", len(ter.Variables))
 		t.Errorf("Variables found: %s", ter.Variables)
 	}
 

--- a/terraform.go
+++ b/terraform.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -20,4 +21,8 @@ func (t *terraformVars) matchVarPref(row, varPrefix string) {
 			}
 		}
 	}
+}
+
+func (t *terraformVars) sortVars() {
+	sort.Sort(sort.StringSlice(t.Variables))
 }

--- a/terraform.go
+++ b/terraform.go
@@ -12,10 +12,10 @@ type terraformVars struct {
 
 func (t *terraformVars) matchVarPref(row, varPrefix string) {
 	if strings.Contains(row, varPrefix) {
-		pattern := regexp.MustCompile(`var.([a-z?0-9?_][a-z?0-9?_?-]*)`)
-		match := pattern.FindAllStringSubmatch(row, 1)
-		if len(match) != 0 {
-			res := replacer.Replace(match[0][0])
+		pattern := regexp.MustCompile(`var.([a-z?A-Z?0-9?_][a-z?A-Z?0-9?_?-]*)`)
+		match := pattern.FindAllStringSubmatch(row, -1)
+		for _, m := range match {
+			res := replacer.Replace(m[0])
 			if !containsElement(t.Variables, res) {
 				t.Variables = append(t.Variables, res)
 			}

--- a/terraform.go
+++ b/terraform.go
@@ -11,7 +11,7 @@ type terraformVars struct {
 
 func (t *terraformVars) matchVarPref(row, varPrefix string) {
 	if strings.Contains(row, varPrefix) {
-		pattern := regexp.MustCompile(`var.([a-z?_]+)`)
+		pattern := regexp.MustCompile(`var.([a-z?0-9?_][a-z?0-9?_?-]*)`)
 		match := pattern.FindAllStringSubmatch(row, 1)
 		if len(match) != 0 {
 			res := replacer.Replace(match[0][0])


### PR DESCRIPTION
Hey, thanks for creating this tool!

Firstly I had some trouble when running it against variables with numerical characters so I changed the regex matcher to use the same pattern that Terraform uses.

Secondly I added a sort function so that the variables are written to file in order.

And finally I changed the indentation of the variable blocks to use a single tab instead of three spaces. This matches what `terraform fmt` would do.
